### PR TITLE
Added new USB touchpad id

### DIFF
--- a/AlpsT4USB/AlpsT4USB.cpp
+++ b/AlpsT4USB/AlpsT4USB.cpp
@@ -137,6 +137,7 @@ bool AlpsT4USBEventDriver::handleStart(IOService* provider) {
     switch (hid_interface->getProductID()) {
             
         case HID_PRODUCT_ID_T4_USB:
+        case HID_PRODUCT_ID_G1:
             dev_type = T4;
             break;
         case HID_PRODUCT_ID_U1:

--- a/AlpsT4USB/AlpsT4USB.hpp
+++ b/AlpsT4USB/AlpsT4USB.hpp
@@ -38,6 +38,7 @@ for the alps t4 touchpad (https://github.com/torvalds/linux/blob/master/drivers/
 
 #define HID_PRODUCT_ID_U1_DUAL      0x120B
 #define HID_PRODUCT_ID_T4_BTNLESS   0x120C
+#define HID_PRODUCT_ID_G1           0x120D
 #define HID_PRODUCT_ID_U1           0x1209
 #define HID_PRODUCT_ID_T4_USB       0X1216
 #define ALPS_VENDOR                 0x44e


### PR DESCRIPTION
Adds support for the `0x120d` version of the Alps T4 USB. 